### PR TITLE
Adding param to hide "Built by"

### DIFF
--- a/cart/tmpl/default.php
+++ b/cart/tmpl/default.php
@@ -238,8 +238,13 @@ if(count($this->cart->products) == 0)
 			</div>
 			<?php endif; ?>		
 	</div>	
-	<div class="opg-margin" title="Gnereic VMonepage" style="text-align:right; clear:both;"><small class="opg-text-muted"><a class="opg-link opg-text-muted" href="http://www.vmuikit.com" target="_blank">VMuikit</a> is built by <a href="http://www.joomlaprofessionals.com" title="Joomla Pros / Professionals" target="_blank" class="opg-link opg-text-muted">joomlaprofessionals.com</a></small></div>
+    <?php
+    if($params->get("built_by") == 1)
+    {
+    ?>
+	    <div class="opg-margin" title="Gnereic VMonepage" style="text-align:right; clear:both;"><small class="opg-text-muted"><a class="opg-link opg-text-muted" href="http://www.vmuikit.com" target="_blank">VMuikit</a> is built by <a href="http://www.joomlaprofessionals.com" title="Joomla Pros / Professionals" target="_blank" class="opg-link opg-text-muted">joomlaprofessionals.com</a></small></div>
 <?php
+    }
 }
 else
 {
@@ -301,10 +306,16 @@ else
 		 </div>
 		 
      </div><!-- CART CONTENT DIV END -->
-	  <?php
-	  	echo $this->loadTemplate('modalpage');
-	  ?>
-	 <p style="text-align: center;"><small style="text-size:8px; color:#b4b4b4;"><a style="text-size:8px; color:#b4b4b4;" title="one page checkout virtuemart" target="_blank" href="http://vmonepage.com">VMonepage</a>&nbsp;is built by&nbsp;<a style="text-size:8px; color:#b4b4b4;" title="joomlaproffs webshop ecommerce" target="_blank" href="http://www.joomlaprofessionals.com">joomlaprofessionals.com</a></small></p>
+	 <?php
+	 echo $this->loadTemplate('modalpage');
+
+	 if($params->get("built_by") == 1)
+	 {
+	 ?>
+    	 <p style="text-align: center;"><small style="text-size:8px; color:#b4b4b4;"><a style="text-size:8px; color:#b4b4b4;" title="one page checkout virtuemart" target="_blank" href="http://vmonepage.com">VMonepage</a>&nbsp;is built by&nbsp;<a style="text-size:8px; color:#b4b4b4;" title="joomlaproffs webshop ecommerce" target="_blank" href="http://www.joomlaprofessionals.com">joomlaprofessionals.com</a></small></p>
+	 <?php
+	 }
+	 ?>
 </form>
 
 <?php

--- a/onepage_generic.xml
+++ b/onepage_generic.xml
@@ -131,7 +131,10 @@
 						</field>
 						<field 	name="recaptchakey" type="text" class="btn-group btn-group-yesno" label="Recaptcha Key"  description="" default="" />	
 						<field 	name="secretkey" type="text" class="btn-group btn-group-yesno" label="Recaptcha Secret Key"  description="" default="" />	
-
+						<field 	name="built_by"	type="radio" class="btn-group btn-group-yesno"	label="Display built by footer" description="Do you want to display a backlink to http://vmonepage.com and http://www.joomlaprofessionals.com/ to support the project?" default="1">
+							<option value="0">JNO</option>
+							<option value="1">JYES</option>
+						</field>
 
 	                </fieldset>
 


### PR DESCRIPTION
Sometimes the backlinks just don't "fit", and store owners want to hide them.
Sure they can add a design override, but then the file might be forgotten, and not being updated.

Also it's more or less common and expected to have a setting like this in components and plugins (for front-end displays) ...